### PR TITLE
Bump lens version.

### DIFF
--- a/http2-client-grpc.cabal
+++ b/http2-client-grpc.cabal
@@ -23,7 +23,7 @@ library
                      , bytestring >= 0.10.8 && < 0.10.9
                      , case-insensitive >= 1.2.0 && < 1.3
                      , data-default-class >= 0.1 && <0.2
-                     , lens >= 4.16 && < 4.17
+                     , lens >= 4.16 && < 4.18
                      , http2 >= 1.6 && < 1.7
                      , http2-client >= 0.8 && < 0.9
                      , http2-grpc-types >= 0.3 && < 0.4


### PR DESCRIPTION
It allows the library to build on GHC 8.6.*. By the way, I need you to cut a new release so I can make both `grpc-api-etcd` and `grpc-etcd-client` build on GHC 8.6.