### PR TITLE
Support GHC 8.8

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,9 @@
 
 ## Unreleased changes
 
-## 0.6.0.0
+- Support GHC 8.8
+
+## 0.7.0.0
 
 Update to http2-client-0.9.0.0
 

--- a/http2-client-grpc.cabal
+++ b/http2-client-grpc.cabal
@@ -1,5 +1,5 @@
 name:                http2-client-grpc
-version:             0.7.0.1
+version:             0.7.1.0
 synopsis:            Implement gRPC-over-HTTP2 clients.
 description:         A gRPC over http2-client using proto-lens to generate client code.
 homepage:            https://github.com/lucasdicioccio/http2-client-grpc#readme
@@ -20,18 +20,18 @@ library
   build-depends:       base >= 4.11 && < 5
                      , async >= 2.2 && < 2.3
                      , binary >= 0.8 && < 0.9
-                     , bytestring >= 0.10.8 && < 0.10.9
+                     , bytestring >= 0.10.8 && < 0.10.10
                      , case-insensitive >= 1.2.0 && < 1.3
                      , data-default-class >= 0.1 && <0.2
-                     , lens >= 4.16 && < 4.18
+                     , lens >= 4.16 && < 4.19
                      , lifted-async >= 0.10 && < 0.11
                      , lifted-base >= 0.2 && < 0.3
-                     , http2 >= 1.6 && < 1.7
+                     , http2 >= 1.6 && < 2.1
                      , http2-client >= 0.9 && < 0.10
                      , http2-grpc-types >= 0.4 && < 0.5
-                     , proto-lens >= 0.5 && < 0.6
+                     , proto-lens >= 0.5 && < 0.7
                      , text >= 1.2 && < 1.3
-                     , tls >= 1.4 && < 1.5
+                     , tls >= 1.4 && < 1.6
   default-language:    Haskell2010
 
 test-suite http2-client-grpc-test

--- a/stack-nightly-2019-11-01.yaml
+++ b/stack-nightly-2019-11-01.yaml
@@ -1,0 +1,8 @@
+resolver: nightly-2019-11-01
+packages:
+- '.'
+extra-deps:
+- http2-client-0.9.1.0
+- http2-grpc-types-0.4.1.0
+flags: {}
+extra-package-dbs: []


### PR DESCRIPTION
Depends on the release of https://github.com/lucasdicioccio/http2-grpc-types/pull/2 and https://github.com/lucasdicioccio/http2-client/pull/72